### PR TITLE
Update CONTRIBUTING.md with instructions on adding a Cookbook to the gallery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ background knowledge.
 The following is a step-by-step guide to getting your cookbook idea
 hosted on the [Project Pythia Cookbooks gallery](https://cookbooks.projectpythia.org).
 
+Before you begin, ask yourself if the content you are developing for a cookbook would be better suited as an addition to an existing cookbook.
+
 1. Use the template
     1. If you don't already have a GitHub account, create one by following the [Getting Started with GitHub guide](https://foundations.projectpythia.org/foundations/getting-started-github.html)
     1. On https://github.com/ProjectPythiaCookbooks/cookbook-template, click "Use this template"
@@ -25,12 +27,20 @@ hosted on the [Project Pythia Cookbooks gallery](https://cookbooks.projectpythia
     1. Add the notebooks to `_toc.yml`. See [`radar-cookbook/_toc.yml`](https://github.com/ProjectPythiaCookbooks/radar-cookbook/blob/main/_toc.yml) for syntax
     1. Replace the `thumbnail.svg` with a thumbnail image relevant to your cookbook
     1. Change `README.md` to include your cookbook title, a sentence or two describing the cookbook, and if desired embed your thumbnail image. See the [Radar Cookbook](https://github.com/ProjectPythiaCookbooks/radar-cookbook/blob/main/README.md) for an example
-    1. In the badge links in `README.md`, change `cookbook-template` to your cookbook repo name.
+    1. In the badge links in `README.md`, change `cookbook-template` to your cookbook repo name
+    1. Replace the `title`, `author`, `description`, `thumbnail`, and the domain and package `tags` fields in the `_config.py` file with values relevant to your cookbook. These values will affect how information about your cookbook is displayed in the gallery.
     1. Commit your changes with git, and [open a Pull Request](https://foundations.projectpythia.org/foundations/github/github-pull-request.html) on your cookbook repo. When you open a PR there, the github-actions bot will comment a link to a preview of your cookbook
 1. Transfer cookbook to the [ProjectPythiaCookbooks](https://github.com/ProjectPythiaCookbooks) organization
     1. Navigate to the settings of your repo, scroll down to the Danger Zone, and click "Transfer"
-        1. For ProjectPythiaCookbooks owners or members: type "ProjectPythiaCookbooks", confirm, and transfer.
+        1. For ProjectPythiaCookbooks owners or members: type "ProjectPythiaCookbooks", confirm, and transfer
         1. For outside contributors: 
             1. Contact an owner of ProjectPythiaCookbooks to be added as an outside collaborator. Then transfer to ProjectPythiaCookbooks; or
             1. Type the username of an owner or member. They will then tranfer it to ProjectPythiaCookbooks and add you as an outside collaborator on that repo
+    1. Replace the `repository_url` in the `sphinx/config/html_theme_options` of the `_config.py` file to point to your cookbook's GitHub repository within the [ProjectPythiaCookbooks](https://github.com/ProjectPythiaCookbooks) organization
     1. Open issues, PRs, and continue making edits as necessary
+
+1. Add your Cookbook to the Cookbook gallery!
+    1. Navigate to the [Cookbooks Gallery](https://cookbooks.projectpythia.org/)
+    1. Click the "Submit a New Cookbook" button, which will redirect you to a [new cookbook PR template](https://github.com/ProjectPythiaCookbooks/projectpythiacookbooks.github.io/issues/new?assignees=ProjectPythiaCookbooks%2Feducation&labels=content%2Ccookbook-gallery-submission&template=update-cookbook-gallery.yaml&title=Update+Gallery+with+new+Cookbook)
+    1. Add the root name of your cookbook repository in the relevant field and any other information you'd like the team to know
+    1. Your request will be reviewed, and you will be notified once your content has been accepted or if changes are requested

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Before you begin, ask yourself if the content you are developing for a cookbook 
     1. Replace the `thumbnail.svg` with a thumbnail image relevant to your cookbook
     1. Change `README.md` to include your cookbook title, a sentence or two describing the cookbook, and if desired embed your thumbnail image. See the [Radar Cookbook](https://github.com/ProjectPythiaCookbooks/radar-cookbook/blob/main/README.md) for an example
     1. In the badge links in `README.md`, change `cookbook-template` to your cookbook repo name
-    1. Replace the `title`, `author`, `description`, `thumbnail`, and the domain and package `tags` fields in the `_config.py` file with values relevant to your cookbook. These values will affect how information about your cookbook is displayed in the gallery.
+    1. Replace the `title`, `author`, `description`, `thumbnail`, and the domain and package `tags` fields in the `_config.yml` file with values relevant to your cookbook. These values will affect how information about your cookbook is displayed in the gallery.
     1. Commit your changes with git, and [open a Pull Request](https://foundations.projectpythia.org/foundations/github/github-pull-request.html) on your cookbook repo. When you open a PR there, the github-actions bot will comment a link to a preview of your cookbook
 1. Transfer cookbook to the [ProjectPythiaCookbooks](https://github.com/ProjectPythiaCookbooks) organization
     1. Navigate to the settings of your repo, scroll down to the Danger Zone, and click "Transfer"
@@ -36,7 +36,7 @@ Before you begin, ask yourself if the content you are developing for a cookbook 
         1. For outside contributors: 
             1. Contact an owner of ProjectPythiaCookbooks to be added as an outside collaborator. Then transfer to ProjectPythiaCookbooks; or
             1. Type the username of an owner or member. They will then tranfer it to ProjectPythiaCookbooks and add you as an outside collaborator on that repo
-    1. Replace the `repository_url` in the `sphinx/config/html_theme_options` of the `_config.py` file to point to your cookbook's GitHub repository within the [ProjectPythiaCookbooks](https://github.com/ProjectPythiaCookbooks) organization
+    1. Replace the `repository_url` in the `sphinx/config/html_theme_options` of the `_config.yml` file to point to your cookbook's GitHub repository within the [ProjectPythiaCookbooks](https://github.com/ProjectPythiaCookbooks) organization
     1. Open issues, PRs, and continue making edits as necessary
 
 1. Add your Cookbook to the Cookbook gallery!


### PR DESCRIPTION
Two main pieces that were missing: updating the `_config.py` which affects how the gallery card will be displayed and using the "submit new cookbook" button to add your cookbook.